### PR TITLE
Remove duplicate initialization logs

### DIFF
--- a/main.py
+++ b/main.py
@@ -48,11 +48,9 @@ class DetectionSystem:
             self.camera = None
 
     def initialize_inference_engine(self):
-        self.logger.logger.info("正在初始化推理引擎...")
         if not self.inference_engine.initialize():
             self.logger.logger.error("推理引擎初始化失敗")
             raise RuntimeError("推理引擎初始化失敗")
-        self.logger.logger.info("推理引擎初始化成功")
 
     def initialize_product_models(self, product):
         """初始化指定機種的所有模型"""


### PR DESCRIPTION
## Summary
- remove redundant inference engine initialization logs from main entry point

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'cv2')*


------
https://chatgpt.com/codex/tasks/task_e_689ab471b8008326a9a91ae90bf544ca