### PR TITLE
docs: 更新安裝與執行說明

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,64 +1,100 @@
 # YoloVision
 
-YoloVision 是一個使用 **YOLO** 模型與 **海康威視 MVS 相機** 進行即時目標檢測的範例程式。程式透過 `config.yaml` 進行設定，並可將檢測結果與相關影像存入 `Result/` 目錄下，同時使用 `logs/` 記錄過程。
+YoloVision 是示範如何整合 **YOLO** 與 **Anomalib** 進行產品檢測的範例專案。系統會依據 `config.yaml` 與 `models/` 內的設定進行推論，並將結果輸出至 `Result/` 目錄與 `logs/` 日誌檔。
 
 ## 主要功能
 
-- 從 MVS 相機擷取影像並進行前處理
-- 使用 Ultralytics YOLO 模型推論
-- 根據產品與檢測區域比對預期項目
-- 將結果、裁切影像與紀錄存檔
+- 從海康威視 MVS 相機擷取影像，無相機時使用模擬圖像。
+- 支援 YOLO 與 Anomalib 推論模式，可依產品與區域切換。
+- 儲存原始圖像、前處理圖像、標註結果、裁切區塊與 Excel 紀錄。
 
 ## 安裝
 
 1. 安裝 Python 3.9 以上版本。
-2. 安裝必要套件（示例）：
+2. 建議使用虛擬環境（venv 或 conda）。
+3. 安裝依賴套件：
+
    ```bash
-   pip install torch ultralytics opencv-python numpy pandas openpyxl
+   pip install -r requirements.txt
    ```
-3. 將預訓練模型 `best.pt` 放置於專案根目錄。
 
-## 設定檔說明
+4. 將 YOLO 權重檔與 Anomalib 模型檔放入 `models/` 對應資料夾。
 
-`config.yaml` 內包含模型路徑、裝置、影像大小、曝光設定與各產品區域應有的元件。例如：
+## 設定
+
+### 全域設定：`config.yaml`
+
+設定相機參數與預設選項，例如曝光、解析度與是否啟用 YOLO 或 Anomalib。
 
 ```yaml
-weights: "best.pt"
-device: "cpu"
-imgsz: [640, 640]
-expected_items:
-  PCBA1:
-    A:
-      - weld_1
-      - weld_2
-    B:
-      - con1
+exposure_time: "20000"
+gain: "15.0"
+enable_yolo: false
+enable_anomalib: false
 ```
 
-可依需求調整各項參數及 `expected_items` 內容。
+### 模型設定
+
+模型檔案位於 `models/<產品>/<區域>/<推論類型>/config.yaml`。依需求提供 YOLO 或 Anomalib 設定：
+
+**YOLO 範例：**
+
+```yaml
+weights: "yolo_best.pt"
+device: "cuda:0"
+conf_thres: 0.25
+iou_thres: 0.45
+imgsz: [640, 640]
+expected_items:
+  A:
+    - weld_1
+    - weld_2
+```
+
+**Anomalib 範例：**
+
+```yaml
+device: "cuda:0"
+imgsz: [640, 640]
+width: 640
+height: 640
+anomalib_config: "path/to/anomalib/model/config.yaml"
+```
 
 ## 執行
 
-直接執行 `Inference.py` 即可啟動推論流程：
+以 `main.py` 啟動系統：
 
 ```bash
-python Inference.py
+python main.py
 ```
 
-程式會依序讀取 `config.yaml`、連接相機、取得畫面並進行檢測。結果影像會輸出至 `Result/` 子目錄，Excel 紀錄檔儲存於同處。
+步驟：
 
-## 目錄結構
+1. 輸入機種名稱。
+2. 輸入 `區域,推論類型`，例如 `A,yolo` 或 `B,anomalib`。
+3. 程式會載入對應設定並輸出檢測結果。
 
-- `Inference.py`：主推論程式。
-- `MVS_camera_control.py`：MVS 相機操作與控制。
-- `core/`：包含偵測、記錄與結果處理等模組。
-- `config.yaml`：範例設定檔，可自行修改。
-- `Result/`：存放偵測結果與紀錄。
-- `logs/`：執行時的 log 檔案。
+## 檔案輸出
+
+所有結果儲存在 `Result/` 目錄，下層依日期與結果狀態（PASS、FAIL）分類，結構如下：
+
+```
+Result/<日期>/<狀態>/
+ ├─ original/          # 原始影像
+ ├─ preprocessed/      # 前處理影像
+ ├─ annotated/         # 標註或熱圖
+ └─ cropped/           # YOLO 裁切圖像
+```
+
+- `results.xlsx`：每次檢測的統計資訊。
+- `logs/detection_YYYYMMDD.log`：日誌紀錄。
+
+YOLO 模式會輸出偵測框與裁切影像；Anomalib 模式會輸出異常熱圖與異常分數。
 
 ## 注意事項
 
-- 使用前需安裝並正確設定相機 SDK。
-- `best.pt` 及 `yolo11_best.pt` 為模型檔案，容量較大，請依實際需求選擇。
-- 若需自訂測試流程，可修改 `Inference.py` 中 `main()` 的示例程式碼。
+- 必須先安裝並設定相機 SDK，否則將改用模擬圖像。
+- 模型檔案需自行準備並放置於 `models/` 對應位置。
+- 若需自訂流程，可修改 `main.py` 內部邏輯。
 


### PR DESCRIPTION
## Summary
- 更新 README，改以 `main.py` 為範例並重寫安裝與設定步驟
- 加入 YOLO 與 Anomalib 雙模式配置與輸出說明

## Testing
- `python -m py_compile main.py`

------
https://chatgpt.com/codex/tasks/task_e_689b0e706a3c83268e42e142084c8c9e