### PR TITLE
feat: 使用 openpyxl 追加寫入並加入備援機制

### DIFF
--- a/core/result_handler.py
+++ b/core/result_handler.py
@@ -8,6 +8,9 @@ import numpy as np
 from ultralytics.utils.plotting import colors
 from core.logger import DetectionLogger
 import shutil
+from openpyxl import load_workbook
+import time
+
 
 class ResultHandler:
     def __init__(self, config, base_dir: str = "Result", logger: DetectionLogger = None):
@@ -18,50 +21,84 @@ class ResultHandler:
         self.excel_path = os.path.join(self.base_dir, "results.xlsx")
         self.image_utils = ImageUtils()
         self.detection_results = DetectionResults(config)
+        self.columns = [
+            "時間戳記", "測試編號", "產品", "區域", "模型類型", "結果", "信心分數", "異常分數",
+            "錯誤訊息", "標註影像路徑", "原始影像路徑", "預處理圖像路徑",
+            "異常熱圖路徑", "裁剪圖像路徑", "檢查點路徑"
+        ]
         os.makedirs(self.base_dir, exist_ok=True)
         if not os.path.exists(self.excel_path):
             self._initialize_excel()
 
     def _initialize_excel(self) -> None:
-        columns = [
-            "時間戳記", "測試編號", "產品", "區域", "結果", "信心分數", "異常分數", 
-            "錯誤訊息", "標註影像路徑", "原始影像路徑", "預處理圖像路徑", 
-            "異常熱圖路徑", "裁剪圖像路徑", "檢查點路徑"
-        ]
-        df = pd.DataFrame(columns=columns)
+        df = pd.DataFrame(columns=self.columns)
         df.to_excel(self.excel_path, index=False, engine='openpyxl')
 
     def _read_excel(self) -> pd.DataFrame:
-        try:
-            if os.path.exists(self.excel_path):
-                return pd.read_excel(self.excel_path, engine='openpyxl')
-            return pd.DataFrame(columns=[
-                "時間戳記", "測試編號", "產品", "區域", "結果", "信心分數", "異常分數", 
-                "錯誤訊息", "標註影像路徑", "原始影像路徑", "預處理圖像路徑", 
-                "異常熱圖路徑", "裁剪圖像路徑", "檢查點路徑"
-            ])
-        except Exception as e:
-            self.logger.logger.error(f"讀取 Excel 時發生錯誤: {str(e)}")
-            return pd.DataFrame(columns=[
-                "時間戳記", "測試編號", "產品", "區域", "結果", "信心分數", "異常分數", 
-                "錯誤訊息", "標註影像路徑", "原始影像路徑", "預處理圖像路徑", 
-                "異常熱圖路徑", "裁剪圖像路徑", "檢查點路徑"
-            ])
+        backup_path = self.excel_path + ".bak"
+        for attempt in range(3):
+            try:
+                if os.path.exists(self.excel_path):
+                    return pd.read_excel(self.excel_path, engine='openpyxl')
+                return pd.DataFrame(columns=self.columns)
+            except Exception as e:
+                self.logger.logger.error(f"讀取 Excel 時發生錯誤（第{attempt + 1}次）: {str(e)}")
+                time.sleep(0.5)
+                if os.path.exists(backup_path):
+                    self.logger.logger.warning(f"嘗試從備份讀取 {backup_path}")
+                    try:
+                        return pd.read_excel(backup_path, engine='openpyxl')
+                    except Exception as be:
+                        self.logger.logger.error(f"讀取備份失敗: {str(be)}")
+        return pd.DataFrame(columns=self.columns)
+
+    def _get_next_test_id(self) -> int:
+        backup_path = self.excel_path + ".bak"
+        for attempt in range(3):
+            try:
+                if os.path.exists(self.excel_path):
+                    wb = load_workbook(self.excel_path)
+                    sheet = wb.active
+                    return sheet.max_row
+                return 1
+            except Exception as e:
+                self.logger.logger.error(f"取得測試編號失敗（第{attempt + 1}次）: {str(e)}")
+                time.sleep(0.5)
+                if os.path.exists(backup_path):
+                    shutil.copy(backup_path, self.excel_path)
+        return 1
 
     def _append_to_excel(self, data: Dict) -> None:
-        try:
-            df = self._read_excel()
-            if isinstance(data.get('時間戳記'), datetime):
-                data['時間戳記'] = data['時間戳記'].strftime('%Y-%m-%d %H:%M:%S')
-            new_row = pd.DataFrame([data])
-            new_row = new_row.dropna(axis=1, how='all')
-            df = pd.concat([df, new_row], ignore_index=True)
-            df.to_excel(self.excel_path, index=False, engine='openpyxl')
-            self.logger.logger.info(f"Excel 數據已保存至 {self.excel_path}")
-        except PermissionError:
-            self.logger.logger.error(f"權限拒絕，無法寫入 {self.excel_path}，請檢查檔案是否被占用或權限設置")
-        except Exception as e:
-            self.logger.logger.error(f"寫入 Excel 時發生錯誤: {str(e)}")
+        backup_path = self.excel_path + ".bak"
+        row = []
+        for col in self.columns:
+            value = data.get(col, "")
+            if col == "時間戳記" and isinstance(value, datetime):
+                value = value.strftime('%Y-%m-%d %H:%M:%S')
+            row.append(value)
+
+        for attempt in range(3):
+            try:
+                if os.path.exists(self.excel_path):
+                    shutil.copy(self.excel_path, backup_path)
+                wb = load_workbook(self.excel_path)
+                ws = wb.active
+                ws.append(row)
+                wb.save(self.excel_path)
+                if os.path.exists(backup_path):
+                    os.remove(backup_path)
+                self.logger.logger.info(f"Excel 數據已保存至 {self.excel_path}")
+                return
+            except PermissionError:
+                self.logger.logger.error(f"權限拒絕，無法寫入 {self.excel_path}，請檢查檔案是否被占用或權限設置")
+            except Exception as e:
+                self.logger.logger.error(f"寫入 Excel 時發生錯誤（第{attempt + 1}次）: {str(e)}")
+            time.sleep(0.5)
+
+        if os.path.exists(backup_path):
+            shutil.copy(backup_path, self.excel_path)
+            self.logger.logger.warning(f"已從備份恢復 {self.excel_path}")
+            os.remove(backup_path)
 
     def _draw_detection_box(self, frame: np.ndarray, detection: Dict) -> None:
         x1, y1, x2, y2 = detection['bbox']
@@ -75,22 +112,35 @@ class ResultHandler:
         current_date = datetime.now().strftime("%Y%m%d")
         time_stamp = datetime.now().strftime("%H%M%S")
         base_path = os.path.join(self.base_dir, current_date, status, "annotated", detector.lower())
-        
+
         if detector.lower() == "anomalib" and anomaly_score is not None:
             image_name = f"{detector.lower()}_{product}_{area}_{time_stamp}_{anomaly_score:.4f}.jpg"
         else:
             image_name = f"{detector.lower()}_{product}_{area}_{time_stamp}.jpg" if product and area else f"{detector.lower()}_{time_stamp}.jpg"
-        
+
         os.makedirs(base_path, exist_ok=True)
         return os.path.join(base_path, image_name)
 
-    def save_results(self, frame: np.ndarray, detections: List[Dict[str, Any]], status: str, detector: str, missing_items: List[str], processed_image: np.ndarray, anomaly_score: float = None, heatmap_path: str = None, product: str = None, area: str = None, ckpt_path: str = None) -> Dict:
+    def save_results(
+        self,
+        frame: np.ndarray,
+        detections: List[Dict[str, Any]],
+        status: str,
+        detector: str,
+        missing_items: List[str],
+        processed_image: np.ndarray,
+        anomaly_score: float = None,
+        heatmap_path: str = None,
+        product: str = None,
+        area: str = None,
+        ckpt_path: str = None,
+    ) -> Dict:
         try:
             current_date = datetime.now().strftime("%Y%m%d")
             time_stamp = datetime.now().strftime("%H%M%S")
             base_path = os.path.join(self.base_dir, current_date, status)
             detector_prefix = detector.lower()
-            
+
             os.makedirs(os.path.join(base_path, "original", detector_prefix), exist_ok=True)
             os.makedirs(os.path.join(base_path, "preprocessed", detector_prefix), exist_ok=True)
             os.makedirs(os.path.join(base_path, "annotated", detector_prefix), exist_ok=True)
@@ -102,27 +152,27 @@ class ResultHandler:
 
             original_path = os.path.join(base_path, "original", detector_prefix, image_name)
             cv2.imwrite(original_path, frame)
-            
+
             preprocessed_path = os.path.join(base_path, "preprocessed", detector_prefix, image_name)
             cv2.imwrite(preprocessed_path, cv2.cvtColor(processed_image, cv2.COLOR_RGB2BGR))
-            
+
             # 處理標註影像
             if detector.lower() == "yolo":
                 annotated_frame = processed_image.copy()
                 crop_source = processed_image
-                
+
                 if detections:
                     for det in detections:
                         self._draw_detection_box(annotated_frame, det)
-                
+
                 status_color = (0, 255, 0) if status == "PASS" else (0, 0, 255)
                 text_x = 50
                 text_y = min(50, annotated_frame.shape[0] - 20)
                 self.image_utils.draw_label(annotated_frame, f"Status: {status}", (text_x, text_y), status_color, font_scale=1.0, thickness=2)
-                
+
                 annotated_path = os.path.join(base_path, "annotated", detector_prefix, image_name)
                 cv2.imwrite(annotated_path, cv2.cvtColor(annotated_frame, cv2.COLOR_RGB2BGR))
-                
+
             else:  # Anomalib
                 annotated_path = os.path.join(base_path, "annotated", detector_prefix, image_name)
                 if heatmap_path and os.path.exists(heatmap_path):
@@ -134,7 +184,7 @@ class ResultHandler:
                 else:
                     cv2.imwrite(annotated_path, frame)
                     self.logger.logger.warning("未找到 Anomalib 熱圖，使用原始圖像作為標註影像")
-                
+
                 crop_source = frame
 
             # 處理裁剪圖像（僅對 YOLO 有效）
@@ -160,7 +210,7 @@ class ResultHandler:
 
             excel_data = {
                 "時間戳記": datetime.now(),
-                "測試編號": len(self._read_excel()) + 1,
+                "測試編號": self._get_next_test_id(),
                 "產品": product,
                 "區域": area,
                 "模型類型": detector,
@@ -173,7 +223,7 @@ class ResultHandler:
                 "預處理圖像路徑": preprocessed_path,
                 "異常熱圖路徑": heatmap_dest_path if heatmap_dest_path else "",
                 "裁剪圖像路徑": ";".join(cropped_paths) if cropped_paths else "",
-                "檢查點路徑": ckpt_path or ""
+                "檢查點路徑": ckpt_path or "",
             }
             self._append_to_excel(excel_data)
 
@@ -185,8 +235,9 @@ class ResultHandler:
                 "heatmap_path": heatmap_dest_path,
                 "cropped_paths": cropped_paths,
                 "product": product,
-                "area": area
+                "area": area,
             }
         except Exception as e:
             self.logger.logger.error(f"保存結果失敗: {str(e)}")
             return {"status": "ERROR", "error_message": str(e)}
+

--- a/tests/test_result_handler.py
+++ b/tests/test_result_handler.py
@@ -1,0 +1,40 @@
+import os
+from datetime import datetime
+from openpyxl import load_workbook
+
+from core.result_handler import ResultHandler
+
+
+def dummy_config():
+    return {}
+
+
+def test_append_to_excel_multiple_times(tmp_path):
+    handler = ResultHandler(dummy_config(), base_dir=str(tmp_path))
+    base_data = {
+        "時間戳記": datetime.now(),
+        "產品": "prod",
+        "區域": "A",
+        "模型類型": "yolo",
+        "結果": "PASS",
+        "信心分數": "cls:0.9",
+        "異常分數": 0.1,
+        "錯誤訊息": "",
+        "標註影像路徑": "p1",
+        "原始影像路徑": "p2",
+        "預處理圖像路徑": "p3",
+        "異常熱圖路徑": "",
+        "裁剪圖像路徑": "",
+        "檢查點路徑": "",
+    }
+
+    for i in range(5):
+        data = dict(base_data)
+        data["測試編號"] = i + 1
+        handler._append_to_excel(data)
+
+    wb = load_workbook(handler.excel_path)
+    sheet = wb.active
+    assert sheet.max_row == 6  # 1 header + 5 data rows
+    ids = [row[1].value for row in sheet.iter_rows(min_row=2, max_row=6, values_only=True)]
+    assert ids == [1, 2, 3, 4, 5]


### PR DESCRIPTION
## Summary
- 改以 `openpyxl.load_workbook` 逐列追加結果並加上重試與備份保護
- 以備援方式計算測試編號避免整份 Excel 重讀
- 新增測試驗證連續寫入 Excel 的情境

## Testing
- `pytest tests/test_result_handler.py -q` *(失敗：ModuleNotFoundError: No module named 'openpyxl')*
- `pip install openpyxl opencv-python-headless` *(失敗：403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_689b0e6f0f8483268d39b1e0f5858ff6