### PR TITLE
修正 letterbox 尺寸判斷並新增測試

### DIFF
--- a/core/utils.py
+++ b/core/utils.py
@@ -9,15 +9,15 @@ class ImageUtils:
     @staticmethod
     def letterbox(img, size=(640, 640), fill_color=(128, 128, 128)):
         """
-        等比例縮放圖像並填充到目標尺寸（預設 640x640），保持長寬比。
-        
+        等比例縮放圖像並填充到目標尺寸，保持長寬比。
+
         Args:
             img: 輸入圖像 (numpy array, RGB 格式)
             size: 目標尺寸 (height, width)
             fill_color: 填充顏色 (RGB tuple, 預設灰色 128,128,128)
-        
+
         Returns:
-            resized_img: 調整後的圖像 (RGB 格式, 640x640)
+            resized_img: 調整後的圖像 (RGB 格式，尺寸為 size)
         """
         # 獲取原始圖像尺寸
         h, w = img.shape[:2]
@@ -40,9 +40,9 @@ class ImageUtils:
         # 將縮放後的圖像複製到畫布中心
         padded_img[top:top + new_h, left:left + new_w] = resized_img
         
-        # 確保輸出尺寸為 640x640
-        if padded_img.shape[:2] != (640, 640):
-            padded_img = cv2.resize(padded_img, (640, 640), interpolation=cv2.INTER_AREA)
+        # 確保輸出尺寸符合指定的 size
+        if padded_img.shape[:2] != (target_h, target_w):
+            padded_img = cv2.resize(padded_img, (target_w, target_h), interpolation=cv2.INTER_AREA)
         
         return padded_img
 

--- a/tests/test_letterbox_imgsz.py
+++ b/tests/test_letterbox_imgsz.py
@@ -1,0 +1,22 @@
+import numpy as np
+from core.config import DetectionConfig
+from core.yolo_inference_model import YOLOInferenceModel
+from core.utils import ImageUtils
+
+
+def test_yolo_preprocess_respects_imgsz():
+    cfg = DetectionConfig(weights="")
+    cfg.imgsz = (320, 480)
+    model = YOLOInferenceModel(cfg)
+    dummy = np.zeros((100, 200, 3), dtype=np.uint8)
+    out = model.preprocess_image(dummy, "prod", "area")
+    assert out.shape[:2] == cfg.imgsz
+
+
+def test_anomalib_letterbox_respects_imgsz():
+    cfg = DetectionConfig(weights="")
+    cfg.imgsz = (256, 256)
+    img = np.zeros((50, 100, 3), dtype=np.uint8)
+    utils = ImageUtils()
+    out = utils.letterbox(img, size=cfg.imgsz, fill_color=(0, 0, 0))
+    assert out.shape[:2] == cfg.imgsz


### PR DESCRIPTION
## Summary
- 調整 `ImageUtils.letterbox` 使輸出依據 `size` 參數，不再硬性縮放至 640x640
- 新增單元測試，驗證 YOLO 與 Anomalib 在不同 `imgsz` 下皆可正確處理影像

## Testing
- `pytest tests/test_letterbox_imgsz.py -q` *(失敗：ModuleNotFoundError: No module named 'numpy')*
- `pip install numpy opencv-python -q` *(失敗：HTTP 403 導致無法下載依賴)*

------
https://chatgpt.com/codex/tasks/task_e_689b0e6ed3b483269fb632f34d1e17c0