### PR TITLE
Use logging for YAML loading in DetectionConfig

### DIFF
--- a/core/config.py
+++ b/core/config.py
@@ -1,6 +1,9 @@
 import yaml
+import logging
 from dataclasses import dataclass, field
 from typing import Dict, List, Tuple, Optional
+
+logger = logging.getLogger(__name__)
 
 @dataclass
 class DetectionConfig:
@@ -28,7 +31,7 @@ class DetectionConfig:
     def from_yaml(cls, path: str) -> 'DetectionConfig':
         with open(path, 'r', encoding='utf-8') as f:
             config_dict = yaml.safe_load(f)
-            print("Loaded YAML:", config_dict)
+            logger.debug("Loaded YAML: %s", config_dict)
         return cls(
             weights=config_dict.get('weights'),
             device=config_dict.get('device', 'cpu'),


### PR DESCRIPTION
## Summary
- replace print with `logger.debug` in `DetectionConfig.from_yaml`
- add logging import and logger initialization

## Testing
- `python -m py_compile core/config.py`
- `pytest` *(fails: ModuleNotFoundError: No module named 'cv2')*
- `pip install opencv-python-headless` *(fails: Could not find a version that satisfies the requirement; proxy 403)*

------
https://chatgpt.com/codex/tasks/task_e_689b0e6e074c8326bc424298a23d10ab