### PR TITLE
Add buffered Excel writing with periodic flush

### DIFF
--- a/tests/test_result_handler.py
+++ b/tests/test_result_handler.py
@@ -33,6 +33,9 @@ def test_append_to_excel_multiple_times(tmp_path):
         data["測試編號"] = i + 1
         handler._append_to_excel(data)
 
+    handler.flush()
+    handler.close()
+
     wb = load_workbook(handler.excel_path)
     sheet = wb.active
     assert sheet.max_row == 6  # 1 header + 5 data rows


### PR DESCRIPTION
## Summary
- keep workbook in memory and buffer rows
- add periodic flush and close handlers
- adjust unit tests for buffered ResultHandler

## Testing
- `pytest tests/test_result_handler.py -q` *(fails: No module named 'openpyxl')*

------
https://chatgpt.com/codex/tasks/task_e_689c0487def8832695b8e0bb7e447ab1