### PR TITLE
feat: add LRU model cache

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -6,3 +6,4 @@ width: 3072
 height: 2048
 enable_yolo: false
 enable_anomalib: false
+max_cache_size: 3

--- a/core/config.py
+++ b/core/config.py
@@ -26,6 +26,7 @@ class DetectionConfig:
     output_dir: str = "Result"
     anomalib_config: Optional[Dict] = None
     position_config: Dict[str, Dict[str, Dict]] = field(default_factory=dict)
+    max_cache_size: int = 3
 
     @classmethod
     def from_yaml(cls, path: str) -> 'DetectionConfig':
@@ -51,7 +52,8 @@ class DetectionConfig:
             enable_anomalib=config_dict.get('enable_anomalib', False),
             output_dir=config_dict.get('output_dir', 'Result'),
             anomalib_config=config_dict.get('anomalib_config'),
-            position_config=config_dict.get('position_config', {})
+            position_config=config_dict.get('position_config', {}),
+            max_cache_size=config_dict.get('max_cache_size', 3)
         )
 
     def get_items_by_area(self, product: str, area: str) -> Optional[List[str]]:

--- a/core/inference_engine.py
+++ b/core/inference_engine.py
@@ -54,3 +54,11 @@ class InferenceEngine:
         if inference_type not in self.models:
             raise ValueError(f"未初始化的推理類型: {inference_type}")
         return self.models[inference_type].infer(image, product, area, output_path)
+
+    def shutdown(self):
+        for model in self.models.values():
+            try:
+                model.shutdown()
+            except Exception:
+                pass
+        self.models.clear()

--- a/main.py
+++ b/main.py
@@ -12,6 +12,7 @@ from core.config import DetectionConfig
 from core.logger import DetectionLogger
 from core.inference_engine import InferenceEngine, InferenceType
 from camera.camera_controller import CameraController
+from collections import OrderedDict
 
 # 設置日誌
 logging.basicConfig(
@@ -33,7 +34,8 @@ class DetectionSystem:
         self.result_handler = ResultHandler(self.config, base_dir=self.config.output_dir, logger=self.logger)
         self.inference_engine = None
         self.current_inference_type = None
-        self.model_cache = {}
+        self.model_cache = OrderedDict()
+        self.max_cache_size = self.config.max_cache_size
         self.initialize_camera()
 
     def load_config(self, config_path):
@@ -72,13 +74,14 @@ class DetectionSystem:
 
     def load_model_configs(self, product: str, area: str, inference_type: str) -> None:
         """根據指定產品、區域與模型載入設定並初始化推理引擎"""
-        cache_key = (product, area, inference_type)
+        cache_key = (product, area)
 
-        if cache_key in self.model_cache:
+        if cache_key in self.model_cache and inference_type in self.model_cache[cache_key]:
             self.logger.logger.info(
                 f"使用快取模型: 產品 {product}, 區域 {area}, 模型 {inference_type}"
             )
-            self.inference_engine, cached_config = self.model_cache[cache_key]
+            self.inference_engine, cached_config = self.model_cache[cache_key][inference_type]
+            self.model_cache.move_to_end(cache_key)
             self.config.__dict__.update(copy.deepcopy(cached_config.__dict__))
             self.current_inference_type = inference_type
             return
@@ -136,7 +139,15 @@ class DetectionSystem:
                 raise
 
         self.current_inference_type = inference_type
-        self.model_cache[cache_key] = (self.inference_engine, copy.deepcopy(self.config))
+        if cache_key not in self.model_cache:
+            self.model_cache[cache_key] = {}
+        self.model_cache[cache_key][inference_type] = (self.inference_engine, copy.deepcopy(self.config))
+        self.model_cache.move_to_end(cache_key)
+        if len(self.model_cache) > self.max_cache_size:
+            old_key, engines = self.model_cache.popitem(last=False)
+            for eng, _ in engines.values():
+                eng.shutdown()
+            self.logger.logger.info(f"釋放快取模型: 產品 {old_key[0]}, 區域 {old_key[1]}")
 
     def detect(self, product, area, inference_type):
         try:


### PR DESCRIPTION
## Summary
- add configurable LRU cache for model and config loading
- support cache eviction with shutdown handling

## Testing
- `python -m pytest -q` *(fails: ModuleNotFoundError: No module named 'cv2')*

------
https://chatgpt.com/codex/tasks/task_e_689c0488b6a08326bd40db5b57bb87af