### PR TITLE
Make Anomalib inference DataLoader configurable

### DIFF
--- a/core/anomalib_inference_model.py
+++ b/core/anomalib_inference_model.py
@@ -47,7 +47,8 @@ class AnomalibInferenceModel(BaseInferenceModel):
                 enable_timing=True,
                 product=product,
                 area=area,
-                output_path=output_path
+                output_path=output_path,
+                num_workers=self.config.anomalib_config.get('num_workers', 1) if self.config.anomalib_config else 1
             )
 
             if 'error' in result:

--- a/core/anomalib_lightning_inference.py
+++ b/core/anomalib_lightning_inference.py
@@ -137,7 +137,7 @@ def initialize_product_models(config: dict = None, product: str = None) -> None:
     for area in config['models'][product]:
         initialize(config, product, area)
 
-def lightning_inference(image_path: str = None, image: np.ndarray = None, thread_safe: bool = True, enable_timing: bool = True, product: str = None, area: str = None, output_path: str = None) -> dict:
+def lightning_inference(image_path: str = None, image: np.ndarray = None, thread_safe: bool = True, enable_timing: bool = True, product: str = None, area: str = None, output_path: str = None, num_workers: int = 1) -> dict:
     global _engine, _models, _output_dir, _transform, _inference_lock
 
     model_key = (product, area)
@@ -168,10 +168,10 @@ def lightning_inference(image_path: str = None, image: np.ndarray = None, thread
             dataset = PredictDataset(path=image_path, transform=_transform)
         dataloader = DataLoader(
             dataset,
-            batch_size=16,
-            num_workers=0,
-            pin_memory=False,
-            persistent_workers=False
+            batch_size=1,
+            num_workers=num_workers,
+            pin_memory=True,
+            persistent_workers=num_workers > 0
         )
         if enable_timing:
             timings["dataset_creation"] = round(time.time() - dataset_start, 4)

--- a/models/PCBA1/A/anomalib/config.yaml
+++ b/models/PCBA1/A/anomalib/config.yaml
@@ -10,6 +10,7 @@ anomalib_config:
   output: Result/YYYYMMDD/annotated
   threshold: 0.5
   devices: auto
+  num_workers: 1
   data:
     path: "PCBA_image"
     transform: null


### PR DESCRIPTION
## Summary
- allow `lightning_inference` to accept configurable `num_workers`
- set DataLoader to `batch_size=1`, enable `pin_memory`
- pass `num_workers` from config in `AnomalibInferenceModel` and sample config

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'cv2')*


------
https://chatgpt.com/codex/tasks/task_e_689c23522ee08326a0b62b851a1b949d