### PR TITLE
refactor: use DetectionConfig in result handler tests

### DIFF
--- a/core/result_handler.py
+++ b/core/result_handler.py
@@ -3,6 +3,7 @@ import pandas as pd
 from datetime import datetime
 import cv2
 from typing import List, Dict, Any
+from dataclasses import asdict, is_dataclass
 from .utils import ImageUtils, DetectionResults
 import numpy as np
 from ultralytics.utils.plotting import colors
@@ -16,6 +17,8 @@ import atexit
 
 class ResultHandler:
     def __init__(self, config, base_dir: str = "Result", logger: DetectionLogger = None):
+        if is_dataclass(config):
+            config = asdict(config)
         self.base_dir = base_dir
         self.config = config
         self.logger = logger or DetectionLogger()

--- a/tests/test_result_handler.py
+++ b/tests/test_result_handler.py
@@ -2,11 +2,12 @@ import os
 from datetime import datetime
 from openpyxl import load_workbook
 
+from core.config import DetectionConfig
 from core.result_handler import ResultHandler
 
 
 def dummy_config():
-    return {}
+    return DetectionConfig(weights="")
 
 
 def test_append_to_excel_multiple_times(tmp_path):


### PR DESCRIPTION
## Summary
- allow `ResultHandler` to accept dataclass configs by converting them to dictionaries
- update result handler test to use `DetectionConfig`

## Testing
- `pytest tests/test_result_handler.py::test_append_to_excel_multiple_times -q` *(fails: ModuleNotFoundError: No module named 'openpyxl')*


------
https://chatgpt.com/codex/tasks/task_e_689c378c20288326bc3e3aa19531453b