### PR TITLE
Add buffer config options and use getattr in ResultHandler

### DIFF
--- a/core/config.py
+++ b/core/config.py
@@ -27,6 +27,8 @@ class DetectionConfig:
     anomalib_config: Optional[Dict] = None
     position_config: Dict[str, Dict[str, Dict]] = field(default_factory=dict)
     max_cache_size: int = 3
+    buffer_limit: int = 10
+    flush_interval: float | None = None
 
     @classmethod
     def from_yaml(cls, path: str) -> 'DetectionConfig':
@@ -53,7 +55,9 @@ class DetectionConfig:
             output_dir=config_dict.get('output_dir', 'Result'),
             anomalib_config=config_dict.get('anomalib_config'),
             position_config=config_dict.get('position_config', {}),
-            max_cache_size=config_dict.get('max_cache_size', 3)
+            max_cache_size=config_dict.get('max_cache_size', 3),
+            buffer_limit=config_dict.get('buffer_limit', 10),
+            flush_interval=config_dict.get('flush_interval', None)
         )
 
     def get_items_by_area(self, product: str, area: str) -> Optional[List[str]]:

--- a/core/result_handler.py
+++ b/core/result_handler.py
@@ -38,8 +38,8 @@ class ResultHandler:
 
         # 緩衝設定
         self.buffer: List[List[Any]] = []
-        self.buffer_limit = self.config.get("buffer_limit", 10)
-        self.flush_interval = self.config.get("flush_interval", None)
+        self.buffer_limit = getattr(self.config, "buffer_limit", 10)
+        self.flush_interval = getattr(self.config, "flush_interval", None)
 
         if self.flush_interval:
             self._timer = threading.Timer(self.flush_interval, self._periodic_flush)


### PR DESCRIPTION
## Summary
- add `buffer_limit` and `flush_interval` to `DetectionConfig`
- parse the new options from YAML configs
- use `getattr` in `ResultHandler` for config access

## Testing
- `pytest tests/test_result_handler.py::test_append_to_excel_multiple_times -q` *(fails: ModuleNotFoundError: No module named 'openpyxl')*
- `pip install numpy opencv-python-headless openpyxl` *(fails: Could not find a version that satisfies the requirement numpy)*

------
https://chatgpt.com/codex/tasks/task_e_689c378c51708326a0240833117bc645