### PR TITLE
fix: remove redundant RGB conversion

### DIFF
--- a/core/anomalib_lightning_inference.py
+++ b/core/anomalib_lightning_inference.py
@@ -321,8 +321,7 @@ def _process_prediction(pred, image_path: str, product: str, area: str, output_p
         os.makedirs(os.path.dirname(heatmap_path), exist_ok=True)
 
         overlay_image_bgr = cv2.cvtColor(overlay_image, cv2.COLOR_RGB2BGR)
-        overlay_image_rgb = cv2.cvtColor(overlay_image_bgr, cv2.COLOR_BGR2RGB)
-        cv2.imwrite(heatmap_path, overlay_image_rgb)
+        cv2.imwrite(heatmap_path, overlay_image_bgr)
         logging.getLogger("anomalib").info(f"結果圖片儲存至: {heatmap_path}")
 
         return {


### PR DESCRIPTION
## Summary
- write anomaly heatmap image in BGR format without unnecessary color round-trip

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'cv2')*

------
https://chatgpt.com/codex/tasks/task_e_689c44f437b08326b149e4c701061752