### PR TITLE
Fix color space conversion for temporary inference images

### DIFF
--- a/core/anomalib_lightning_inference.py
+++ b/core/anomalib_lightning_inference.py
@@ -187,7 +187,7 @@ def lightning_inference(image_path: str = None, image: Union[np.ndarray, torch.T
         if model_key not in _dataloaders:
             if image is not None:
                 temp_path = os.path.join(tempfile.gettempdir(), "temp_infer.png")
-                cv2.imwrite(temp_path, cv2.cvtColor(img, cv2.COLOR_BGR2RGB))
+                cv2.imwrite(temp_path, img)
                 dataset = PredictDataset(path=temp_path, transform=_transform)
             else:
                 dataset = PredictDataset(path=image_path, transform=_transform)
@@ -204,7 +204,7 @@ def lightning_inference(image_path: str = None, image: Union[np.ndarray, torch.T
             dataset = _datasets[model_key]
             if image is not None:
                 temp_path = os.path.join(tempfile.gettempdir(), "temp_infer.png")
-                cv2.imwrite(temp_path, cv2.cvtColor(img, cv2.COLOR_BGR2RGB))
+                cv2.imwrite(temp_path, img)
                 dataset.path = temp_path
             else:
                 dataset.path = image_path


### PR DESCRIPTION
## Summary
- stop converting BGR images to RGB before writing temporary inference file

## Testing
- `python -m py_compile core/anomalib_lightning_inference.py`
- `pip install numpy opencv-python openpyxl` *(fails: Cannot connect to proxy)*
- `pytest` *(fails: ModuleNotFoundError: No module named 'cv2')*

------
https://chatgpt.com/codex/tasks/task_e_689c44f635848326af5ec1f9f86a7b61