### PR TITLE
Initialize product area selection on startup

### DIFF
--- a/GUI.py
+++ b/GUI.py
@@ -455,8 +455,7 @@ class DetectionSystemGUI(QMainWindow):
             ]
             
             self.product_combo.clear()
-            self.product_combo.addItems(self.available_products)
-            
+
             # 載入區域
             self.available_areas = {}
             for product in self.available_products:
@@ -466,6 +465,11 @@ class DetectionSystemGUI(QMainWindow):
                     if os.path.isdir(os.path.join(product_dir, d))
                 ]
                 self.available_areas[product] = areas
+
+            self.product_combo.addItems(self.available_products)
+
+            if self.available_products:
+                self.on_product_changed(self.product_combo.currentText())
             
             self.log_message(f"載入了 {len(self.available_products)} 個產品模型")
             


### PR DESCRIPTION
## Summary
- populate area combo when models are loaded so first product's areas are available immediately

## Testing
- `pytest` *(fails: ModuleNotFoundError for cv2, numpy, openpyxl)*
- `pip install numpy openpyxl opencv-python` *(fails: Could not connect to proxy 403)*

------
https://chatgpt.com/codex/tasks/task_e_689ee126eff88326ada5eab126370ec7