### PR TITLE
feat: add color inference model

### DIFF
--- a/core/__init__.py
+++ b/core/__init__.py
@@ -1,5 +1,6 @@
 # core/__init__.py
 from .anomalib_inference_model import AnomalibInferenceModel
+from .color_inference_model import ColorInferenceModel
 
-__all__ = ["AnomalibInferenceModel"]
+__all__ = ["AnomalibInferenceModel", "ColorInferenceModel"]
 __version__ = "0.1.0"  # 可選

--- a/core/color_inference_model.py
+++ b/core/color_inference_model.py
@@ -1,0 +1,98 @@
+import json
+from dataclasses import dataclass
+from typing import List, Tuple, Dict, Any, Optional
+
+import numpy as np
+
+from core.base_model import BaseInferenceModel
+
+
+@dataclass
+class ColorRegion:
+    """表示需要檢測的區域與其目標顏色。"""
+    label: str
+    bbox: Tuple[int, int, int, int]
+    color: Tuple[int, int, int]
+
+
+@dataclass
+class EnhancedReferenceModel:
+    """由 JSON 載入的顏色參考模型。"""
+    regions: List[ColorRegion]
+    threshold: float = 30.0
+
+    @classmethod
+    def from_json(cls, path: str) -> "EnhancedReferenceModel":
+        with open(path, "r", encoding="utf-8") as f:
+            data = json.load(f)
+        threshold = data.get("threshold", 30.0)
+        regions = []
+        for r in data.get("regions", []):
+            label = r.get("label") or r.get("name", "")
+            bbox = tuple(r.get("bbox", (0, 0, 0, 0)))
+            color = tuple(r.get("color", (0, 0, 0)))
+            regions.append(ColorRegion(label, bbox, color))
+        return cls(regions=regions, threshold=threshold)
+
+
+def _mean_color(image: np.ndarray, bbox: Tuple[int, int, int, int]) -> Tuple[int, int, int]:
+    x1, y1, x2, y2 = bbox
+    region = image[y1:y2, x1:x2]
+    if region.size == 0:
+        return 0, 0, 0
+    mean = region.mean(axis=(0, 1))
+    return int(mean[0]), int(mean[1]), int(mean[2])
+
+
+def _color_distance(c1: Tuple[int, int, int], c2: Tuple[int, int, int]) -> float:
+    return float(np.linalg.norm(np.array(c1, dtype=float) - np.array(c2, dtype=float)))
+
+
+def enhanced_detect_one(image: np.ndarray, model: EnhancedReferenceModel) -> Dict[str, Any]:
+    detections = []
+    for region in model.regions:
+        mean_color = _mean_color(image, region.bbox)
+        diff = _color_distance(mean_color, region.color)
+        detections.append({
+            "label": region.label,
+            "bbox": list(region.bbox),
+            "mean_color": mean_color,
+            "target_color": region.color,
+            "color_diff": diff,
+        })
+    status = "PASS" if all(d["color_diff"] <= model.threshold for d in detections) else "FAIL"
+    return {"detections": detections, "status": status, "result_frame": image}
+
+
+class ColorInferenceModel(BaseInferenceModel):
+    def __init__(self, config):
+        super().__init__(config)
+        self.reference_model: Optional[EnhancedReferenceModel] = None
+
+    def initialize(self, product: str = None, area: str = None) -> bool:
+        try:
+            model_path = self.config.color_model_path
+            self.logger.logger.info(f"正在載入顏色模型: {model_path}")
+            self.reference_model = EnhancedReferenceModel.from_json(model_path)
+            self.is_initialized = True
+            return True
+        except Exception as e:
+            self.logger.logger.error(f"顏色模型初始化失敗: {e}")
+            return False
+
+    def infer(self, image: np.ndarray, product: str, area: str, output_path: str = None) -> Dict[str, Any]:
+        if not self.is_initialized or self.reference_model is None:
+            raise RuntimeError("顏色模型未初始化")
+        try:
+            result = enhanced_detect_one(image, self.reference_model)
+            return {
+                "inference_type": "color",
+                "status": result["status"],
+                "detections": result["detections"],
+                "processed_image": image,
+                "result_frame": result.get("result_frame", image),
+                "expected_items": [],
+            }
+        except Exception as e:
+            self.logger.logger.error(f"顏色推理失敗: {e}")
+            raise

--- a/core/config.py
+++ b/core/config.py
@@ -26,6 +26,7 @@ class DetectionConfig:
     output_dir: str = "Result"
     anomalib_config: Optional[Dict] = None
     position_config: Dict[str, Dict[str, Dict]] = field(default_factory=dict)
+    color_model_path: Optional[str] = None
     max_cache_size: int = 3
     buffer_limit: int = 10
     flush_interval: float | None = None
@@ -55,6 +56,7 @@ class DetectionConfig:
             output_dir=config_dict.get('output_dir', 'Result'),
             anomalib_config=config_dict.get('anomalib_config'),
             position_config=config_dict.get('position_config', {}),
+            color_model_path=config_dict.get('color_model_path'),
             max_cache_size=config_dict.get('max_cache_size', 3),
             buffer_limit=config_dict.get('buffer_limit', 10),
             flush_interval=config_dict.get('flush_interval', None)


### PR DESCRIPTION
## Summary
- add color_model_path config option
- implement color inference pipeline with EnhancedReferenceModel and detection helpers
- expose ColorInferenceModel from core package

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'numpy')*
- `pip install numpy==1.26.4` *(fails: Could not find a version that satisfies the requirement numpy==1.26.4)*

------
https://chatgpt.com/codex/tasks/task_e_68ba8bac7eb48326b35e6f6a9a644a9a