### PR TITLE
feat: add color detection option

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,11 @@ exposure_time: "20000"
 gain: "15.0"
 enable_yolo: false
 enable_anomalib: false
+enable_color_detection: false
+color_model_path: ""
 ```
+
+若要啟用顏色檢測，請將 `enable_color_detection` 設為 `true`，並在 `color_model_path` 指定顏色模型的路徑。
 
 ### 模型設定
 
@@ -61,6 +65,12 @@ height: 640
 anomalib_config: "path/to/anomalib/model/config.yaml"
 ```
 
+**顏色檢測範例：**
+
+```yaml
+color_model_path: "path/to/color_model.pt"
+```
+
 ## 執行
 
 以 `main.py` 啟動系統：
@@ -73,6 +83,7 @@ python main.py
 
 1. 輸入機種名稱。
 2. 輸入 `區域,推論類型`，例如 `A,yolo` 或 `B,anomalib`。
+   若要進行顏色檢測，請輸入 `A,color`，並在 `config.yaml` 中啟用 `enable_color_detection` 並設定 `color_model_path`。
 3. 程式會載入對應設定並輸出檢測結果。
 
 ## 檔案輸出

--- a/config.yaml
+++ b/config.yaml
@@ -6,4 +6,6 @@ width: 3072
 height: 2048
 enable_yolo: false
 enable_anomalib: false
+enable_color_detection: false
+color_model_path: ""
 max_cache_size: 3

--- a/core/color_inference_model.py
+++ b/core/color_inference_model.py
@@ -1,0 +1,28 @@
+from core.base_model import BaseInferenceModel
+from core.logger import DetectionLogger
+
+
+class ColorInferenceModel(BaseInferenceModel):
+    """簡易顏色檢測模型範例，回傳原始影像與 PASS 狀態。"""
+
+    def __init__(self, config):
+        super().__init__(config)
+        self.logger = DetectionLogger()
+
+    def initialize(self, product=None, area=None):
+        if not self.config.color_model_path:
+            self.logger.logger.error("未提供顏色模型路徑")
+            return False
+        self.is_initialized = True
+        self.logger.logger.info("顏色檢測模型初始化成功")
+        return True
+
+    def infer(self, image, product, area, output_path=None):
+        if not self.is_initialized:
+            raise RuntimeError("顏色檢測模型尚未初始化")
+        return {
+            "status": "PASS",
+            "processed_image": image,
+            "detections": [],
+            "missing_items": []
+        }

--- a/core/config.py
+++ b/core/config.py
@@ -23,6 +23,8 @@ class DetectionConfig:
     expected_items: Dict[str, Dict[str, List[str]]] = field(default_factory=dict)
     enable_yolo: bool = True
     enable_anomalib: bool = False
+    enable_color_detection: bool = False
+    color_model_path: Optional[str] = None
     output_dir: str = "Result"
     anomalib_config: Optional[Dict] = None
     position_config: Dict[str, Dict[str, Dict]] = field(default_factory=dict)
@@ -52,6 +54,8 @@ class DetectionConfig:
             expected_items=config_dict.get('expected_items', {}),
             enable_yolo=config_dict.get('enable_yolo', True),
             enable_anomalib=config_dict.get('enable_anomalib', False),
+            enable_color_detection=config_dict.get('enable_color_detection', False),
+            color_model_path=config_dict.get('color_model_path'),
             output_dir=config_dict.get('output_dir', 'Result'),
             anomalib_config=config_dict.get('anomalib_config'),
             position_config=config_dict.get('position_config', {}),

--- a/core/inference_engine.py
+++ b/core/inference_engine.py
@@ -4,6 +4,7 @@ from typing import Dict
 from core.base_model import BaseInferenceModel
 from core.yolo_inference_model import YOLOInferenceModel
 from core.anomalib_inference_model import AnomalibInferenceModel
+from core.color_inference_model import ColorInferenceModel
 from core.logger import DetectionLogger
 from core.config import DetectionConfig
 
@@ -11,6 +12,7 @@ from core.config import DetectionConfig
 class InferenceType(Enum):
     YOLO = "yolo"
     ANOMALIB = "anomalib"
+    COLOR = "color"
 
     @classmethod
     def from_string(cls, value: str) -> 'InferenceType':
@@ -40,6 +42,12 @@ class InferenceEngine:
                 anomalib_model = AnomalibInferenceModel(self.config)
                 self.models[InferenceType.ANOMALIB] = anomalib_model
                 self.logger.logger.info("Anomalib 模型已準備")
+
+            if getattr(self.config, 'enable_color_detection', False):
+                color_model = ColorInferenceModel(self.config)
+                if color_model.initialize():
+                    self.models[InferenceType.COLOR] = color_model
+                    self.logger.logger.info("顏色檢測模型已加載")
 
             if not self.models:
                 raise RuntimeError("沒有成功初始化任何推理模型")

--- a/main.py
+++ b/main.py
@@ -115,6 +115,7 @@ class DetectionSystem:
         if inference_type == "yolo":
             self.config.enable_yolo = True
             self.config.enable_anomalib = False
+            self.config.enable_color_detection = False
             self.config.weights = cfg.get("weights")
             self.config.device = cfg.get("device", self.config.device)
             self.config.conf_thres = cfg.get("conf_thres", self.config.conf_thres)
@@ -125,9 +126,20 @@ class DetectionSystem:
             self.config.output_dir = cfg.get("output_dir", self.config.output_dir)
             self.config.position_config = cfg.get("position_config", {})
             self.config.anomalib_config = None
+        elif inference_type == "color":
+            self.config.enable_yolo = False
+            self.config.enable_anomalib = False
+            self.config.enable_color_detection = True
+            self.config.color_model_path = cfg.get("color_model_path", self.config.color_model_path)
+            self.config.output_dir = cfg.get("output_dir", self.config.output_dir)
+            self.config.expected_items = {}
+            self.config.position_config = {}
+            self.config.weights = ""
+            self.config.anomalib_config = None
         else:  # anomalib
             self.config.enable_yolo = False
             self.config.enable_anomalib = True
+            self.config.enable_color_detection = False
             self.config.device = cfg.get("device", self.config.device)
             self.config.imgsz = tuple(cfg.get("imgsz", self.config.imgsz))
             self.config.width = cfg.get("width", self.config.width)
@@ -367,8 +379,8 @@ class DetectionSystem:
                 if area not in available_areas:
                     print(f"無效的區域: {area}，請選擇: {', '.join(available_areas)}")
                     continue
-                if inference_type.lower() not in ["yolo", "anomalib"]:
-                    print("無效的推理類型，應為: yolo 或 anomalib")
+                if inference_type.lower() not in ["yolo", "anomalib", "color"]:
+                    print("無效的推理類型，應為: yolo、anomalib 或 color")
                     continue
 
                 config_path = os.path.join(


### PR DESCRIPTION
## Summary
- support `enable_color_detection` and `color_model_path`
- allow color inference type in CLI and detection system
- add placeholder ColorInferenceModel

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'numpy')*

------
https://chatgpt.com/codex/tasks/task_e_68ba8baee8e8832696d2f6b02340d8ca