### PR TITLE
Add color model config for LED A

### DIFF
--- a/models/LED/A/color/config.yaml
+++ b/models/LED/A/color/config.yaml
@@ -1,0 +1,1 @@
+color_model_path: "models/LED/A/color/enhanced_model.json"


### PR DESCRIPTION
## Summary
- add configuration file for LED A color model

## Testing
- `pytest` *(fails: No module named 'cv2', No module named 'numpy')*

------
https://chatgpt.com/codex/tasks/task_e_68ba82ef20648326997af1720e98d91d