### PR TITLE
feat: add color check options

### DIFF
--- a/core/config.py
+++ b/core/config.py
@@ -23,6 +23,8 @@ class DetectionConfig:
     expected_items: Dict[str, Dict[str, List[str]]] = field(default_factory=dict)
     enable_yolo: bool = True
     enable_anomalib: bool = False
+    enable_color_check: bool = False
+    color_model_path: str | None = None
     output_dir: str = "Result"
     anomalib_config: Optional[Dict] = None
     position_config: Dict[str, Dict[str, Dict]] = field(default_factory=dict)
@@ -52,6 +54,8 @@ class DetectionConfig:
             expected_items=config_dict.get('expected_items', {}),
             enable_yolo=config_dict.get('enable_yolo', True),
             enable_anomalib=config_dict.get('enable_anomalib', False),
+            enable_color_check=config_dict.get('enable_color_check', False),
+            color_model_path=config_dict.get('color_model_path'),
             output_dir=config_dict.get('output_dir', 'Result'),
             anomalib_config=config_dict.get('anomalib_config'),
             position_config=config_dict.get('position_config', {}),

--- a/main.py
+++ b/main.py
@@ -124,6 +124,8 @@ class DetectionSystem:
             self.config.expected_items = cfg.get("expected_items", {})
             self.config.output_dir = cfg.get("output_dir", self.config.output_dir)
             self.config.position_config = cfg.get("position_config", {})
+            self.config.enable_color_check = cfg.get("enable_color_check", self.config.enable_color_check)
+            self.config.color_model_path = cfg.get("color_model_path", self.config.color_model_path)
             self.config.anomalib_config = None
         else:  # anomalib
             self.config.enable_yolo = False
@@ -137,6 +139,8 @@ class DetectionSystem:
             self.config.expected_items = {}
             self.config.position_config = {}
             self.config.weights = ""
+            self.config.enable_color_check = cfg.get("enable_color_check", False)
+            self.config.color_model_path = cfg.get("color_model_path", None)
 
         self.inference_engine = InferenceEngine(self.config)
         self.initialize_inference_engine()

--- a/models/LED/A/yolo/config.yaml
+++ b/models/LED/A/yolo/config.yaml
@@ -6,6 +6,8 @@ imgsz: [640, 640]
 timeout: 1
 current_product: "LED"
 enable_yolo: true
+enable_color_check: true           # 是否啟用顏色檢查
+color_model_path: "path/to/enhanced_model.json"
 output_dir: Result
 
 expected_items:


### PR DESCRIPTION
## Summary
- add color check toggle and model path to LED yolo config
- expose color check fields in `DetectionConfig`
- load color check settings when switching models

## Testing
- `pytest -q` *(fails: No module named 'numpy')*


------
https://chatgpt.com/codex/tasks/task_e_68ba9c694ce083268ad5676927634102