### PR TITLE
refactor: import LEDQCEnhanced directly

### DIFF
--- a/main.py
+++ b/main.py
@@ -14,7 +14,7 @@ from core.logger import DetectionLogger
 from core.inference_engine import InferenceEngine, InferenceType
 from camera.camera_controller import CameraController
 from collections import OrderedDict
-from core import ColorChecker
+from core.led_qc_enhanced import LEDQCEnhanced
 
 # 設置日誌
 logging.basicConfig(
@@ -178,7 +178,6 @@ class DetectionSystem:
             if self.config.enable_color_check and self.config.color_model_path:
                 if self.color_checker is None or self._color_model_path != self.config.color_model_path:
                     try:
-                        from core.led_qc_enhanced import LEDQCEnhanced
                         self.color_checker = LEDQCEnhanced.from_json(self.config.color_model_path)
                         self._color_checker_mode = 'advanced'
                         self._color_model_path = self.config.color_model_path


### PR DESCRIPTION
## Summary
- remove unused ColorChecker import from main entrypoint
- import LEDQCEnhanced at module level and initialize color checker with it

## Testing
- `python -m py_compile main.py`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'core.color_checker'; ModuleNotFoundError: No module named 'numpy')*

------
https://chatgpt.com/codex/tasks/task_e_68be3b81b17483268962b5f471ce334f